### PR TITLE
Feature/#1/dataloader

### DIFF
--- a/dataloader.py
+++ b/dataloader.py
@@ -1,5 +1,5 @@
 import torch
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import Dataset, DataLoader, random_split
 import os
 
 MAX_LENGTH = 800
@@ -46,9 +46,19 @@ def protein_collate_fn(batch):
 if __name__ == "__main__":
     # Example usage
     data_dir = "data"
-    dataset = ProteinDataset(data_dir)
-    dataloader = DataLoader(dataset, batch_size=32, shuffle=True, collate_fn=protein_collate_fn)
+    full_dataset = ProteinDataset(data_dir)
+    total_len = len(full_dataset)
+    train_len = int(0.8 * total_len)
+    val_len = int(0.1 * total_len)
+    test_len = total_len - train_len - val_len
 
-    for batch in dataloader:
+    generator1 = torch.Generator().manual_seed(42)
+    train_ds, val_ds, test_ds = random_split(full_dataset, [train_len, val_len, test_len], 
+                                             generator=generator1)
+
+    train_loader = DataLoader(train_ds, batch_size=32, shuffle=True, collate_fn=protein_collate_fn)
+    val_loader = DataLoader(val_ds, batch_size=32, shuffle=False, collate_fn=protein_collate_fn)
+    test_loader = DataLoader(test_ds, batch_size=32, shuffle=False, collate_fn=protein_collate_fn)
+    for batch in train_loader:
         print(batch.shape)  # torch.Size([32, 800, 1024])
         break

--- a/dataloader.py
+++ b/dataloader.py
@@ -1,0 +1,39 @@
+import torch
+from torch.utils.data import Dataset, DataLoader
+import os
+
+MAX_LENGTH = 800
+EMBED_DIM = 1024
+
+class ProteinDataset(Dataset):
+    def __init__(self, data_dir):
+        self.data_dir = data_dir
+        self.files = [os.path.join(data_dir, f) for f in os.listdir(data_dir) if f.endswith(".embd")][:100]
+
+    def __len__(self):
+        return len(self.files)
+
+    def __getitem__(self, idx):
+        file_path = self.files[idx]
+        embeddings = []
+
+        with open(file_path, 'r') as f:
+            for line in f:
+                _, vec = line.strip().split(':')
+                vec_values = list(map(float, vec.strip().split()))
+                if len(vec_values) != EMBED_DIM:
+                    raise ValueError(f"Expected {EMBED_DIM} values, got {len(vec_values)} in {file_path}")
+                embeddings.append(vec_values)
+
+        embedding_tensor = torch.tensor(embeddings, dtype=torch.float32)  # (L, 1024)
+        return embedding_tensor
+
+if __name__ == "__main__":
+    # Example usage
+    data_dir = "data"
+    dataset = ProteinDataset(data_dir)
+    dataloader = DataLoader(dataset, batch_size=32, shuffle=True)
+    for batch in dataloader:
+        embeddings, aa_sequence = batch  # embeddings: (1, L, 1024), aa_sequence: list of lists
+        print(embeddings.shape, aa_sequence)
+        break


### PR DESCRIPTION
## Add custom DataLoader for protein embeddings

### Summary

This PR adds a custom `ProteinDataset` and `collate_fn` for handling protein data files, where each file represents a protein and each line consists of an amino acid and a 1024-dimensional vector. The collate function ensures all sequences are padded or truncated to `(800, 1024)`.

### What's Included

- `ProteinDataset`: Loads and parses each protein file.
- `protein_collate_fn`: Pads/truncates protein tensors for uniform batching.
- Dataset split: Random 80/10/10 split for train/val/test.
- DataLoader: Created for each split with support for batching.


---

Closes #1 
